### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,5 +15,4 @@ class Category < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -11,5 +11,4 @@ class Condition < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  
 end

--- a/app/models/days_to_ship.rb
+++ b/app/models/days_to_ship.rb
@@ -8,5 +8,4 @@ class DaysToShip < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  
 end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -6,6 +6,5 @@ class DeliveryFee < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-   has_many :items
-  
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,11 +3,15 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to :category, :condition, :prefecture, :delivery_fee, :days_to_ship
-  
+  belongs_to :category
+  belongs_to :condition
+  belongs_to :prefecture
+  belongs_to :delivery_fee
+  belongs_to :days_to_ship
+
   validates :category_id, :condition_id, :prefecture_id, :delivery_fee_id, :days_to_ship_id, numericality: { other_than: 1 }
-  validates :price, numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
-  
+  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+
   with_options presence: true do
     validates :image
     validates :name

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,25 +1,24 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---' },
-    {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-    {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-    {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-    {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-    {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-    {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-    {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-    {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-    {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-    {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-    {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-    {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-    {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-    {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-    {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-    {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    { id: 1, name: '---' },
+    { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
+    { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
+    { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' },
+    { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, { id: 37, name: '徳島県' },
+    { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' },
+    { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-  
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,7 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
+  <% if @items.exists? %>
     <% @items.each do |item| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
@@ -156,6 +156,30 @@
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% end %>
+
+  <% else %>
+      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>
+      <%# //商品がある場合は表示されないようにしましょう %>
+      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+  <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,26 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
+    <% @items.each do |item| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,28 +155,7 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     association :user
 
     after(:build) do |item|
-      item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png' )
+      item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Item, type: :model do
   before do
     @item = FactoryBot.build(:item)
   end
-  
+
   describe '出品商品の登録' do
     context '商品の登録がうまくいくとき' do
       it '必要な情報を適切に入力すると、商品の登録ができる' do
@@ -18,72 +18,70 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include("Image can't be blank")
       end
       it '商品名が空では登録できない' do
-        @item.name = ""
+        @item.name = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Name can't be blank")
       end
       it '商品の説明が空では登録できない' do
-        @item.information = ""
+        @item.information = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Information can't be blank")
       end
       it 'カテゴリーについて --- が選択された場合は登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it '商品の状態について --- が選択された場合は登録できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
       it '配送料の負担について --- が選択された場合は登録できない' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery fee must be other than 1')
       end
       it '発送元の地域について --- が選択された場合は登録できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
       end
       it '発送までの日数について --- が選択された場合は登録できない' do
         @item.days_to_ship_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Days to ship must be other than 1")
+        expect(@item.errors.full_messages).to include('Days to ship must be other than 1')
       end
       it '価格が空では登録できない' do
-        @item.price = ""
+        @item.price = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Price can't be blank")
       end
       it '価格が￥300未満では登録できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it '価格が￥10,000,000以上では登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
       it '価格が半角数字以外で入力された場合登録できない' do
-        @item.price = "１００"
+        @item.price = '１００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '半角英数混合では登録できない' do
-        @item.price = "1000en"
+        @item.price = '1000en'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '半角英語だけでは登録できないこと' do
-        @item.price = "senen"
+        @item.price = 'senen'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
-
     end
   end
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,13 +55,13 @@ RSpec.describe User, type: :model do
         @user.password = '1234567'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password には半角英字と半角数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include('Password には半角英字と半角数字の両方を含めて設定してください')
       end
       it 'passwordに全角が含まれていると登録できない' do
         @user.password = 'test１１１'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password には半角英字と半角数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include('Password には半角英字と半角数字の両方を含めて設定してください')
       end
       it 'passwordとpassword(確認用)が一致しないと登録できない' do
         @user.password_confirmation = 'test222'


### PR DESCRIPTION
# What
商品一覧表示機能を実装

# Why
登録された商品を一覧表示するため
(売却済みの商品については、画像上に『sold out』の文字が表示される機能については後ほど実装します）

## 動作の様子
https://gyazo.com/0056a3f05e05554a05d3bc04f6e9fcca
https://gyazo.com/c394cf81d5e60ec37b1ced475351b969
